### PR TITLE
correct reboot(2) define for OpenBSD

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -41,7 +41,7 @@
 #define NO_GETPGID
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #define Reboot(x) reboot(x)
 #endif
 
@@ -60,7 +60,7 @@
 #define O_EXLOCK 0
 #endif
 
-#if defined(__NetBSD__) || defined(__OpenBSD__)
+#ifdef __NetBSD__
 #define Reboot(x) reboot(x,NULL)
 #endif
 


### PR DESCRIPTION
NetBSD added another argument to the reboot system call in 1996.  OpenBSD has always had a single argument.

Fix the build on OpenBSD by using the same define as FreeBSD.
